### PR TITLE
Issue #6 - ReadDirPlus doesn't work on NFSv4 mounts

### DIFF
--- a/src/nfsiostat.py
+++ b/src/nfsiostat.py
@@ -422,6 +422,8 @@ class DeviceData:
             return (float(self.__rpc_data['backlogutil']) / sends) / sample_time
         else:
             return 0.0
+    def has_readdirplus(self):
+        return self.__rpc_data.has_key('READDIRPLUS')
 
     def display_iostats(self, sample_time, which):
         """Display NFS and RPC stats in an iostat-like way

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -124,7 +124,7 @@ class NFSPlugin(object):
                 self.logger.info("Configured to use proxy: %s:%s" % (proxy_host, proxy_port))
             # Initialize NFS related values
             self.nfs_device_list = json.loads(config.get('nfs','device_list'))
-            self.nfs_ops = ['Read','Write','GetAttr','Access','Lookup','ReadDir']
+            self.nfs_ops = ['Read','Write','GetAttr','Access','Lookup','ReadDir','ReadDirPlus']
 
         except Exception, e:
             self.logger.exception(e)
@@ -182,6 +182,9 @@ class NFSPlugin(object):
             }
 
             for op in (self.nfs_ops):
+                if op.upper() is 'READDIRPLUS' and not volnfsstat.has_readdirplus():
+                    # NFSv4 mounts do not have READDIRPLUS
+                    continue
                 op_stat = volnfsstat.get_rpc_op_stats(op.upper(), self.duration)
                 op_prefix = prefix + op
                 op_data = {


### PR DESCRIPTION
This adds ReadDirPlus back in for NFSv3 mounts, but has an exception
similar to the code used in nfsiostat. I had to expose another method
in nfsiostat.py has_readdirplus() since that was internal only data before.

~tommy
